### PR TITLE
Tweaks for Python 3.5 compatibility

### DIFF
--- a/get_secret_or_env_var/__init__.py
+++ b/get_secret_or_env_var/__init__.py
@@ -67,11 +67,10 @@ class _DockerSecretsDict:
             item = item.decode()
         except AttributeError:
             pass  # Not bytes
-        secrets_path = DOCKER_SECRETS_PATH / item
-        if secrets_path.exists():
-            with open(DOCKER_SECRETS_PATH / item, self.mode) as fin:
+        try:
+            with (DOCKER_SECRETS_PATH / item).open(self.mode) as fin:
                 return fin.read().strip()
-        else:
+        except FileNotFoundError:
             raise KeyError
 
 

--- a/get_secret_or_env_var/__init__.py
+++ b/get_secret_or_env_var/__init__.py
@@ -59,7 +59,7 @@ def _get_secret_or_env_varb(key: bytes, default: Optional[bytes] = None) -> byte
 class _DockerSecretsDict:
     def __init__(self, *, mode):
         if mode not in ("r", "rb"):
-            raise ValueError(f"Mode must be one of 'r' or 'rb', but got {mode}.")
+            raise ValueError("Mode must be one of 'r' or 'rb', but got {}.".format(mode))
         self.mode = mode
 
     def __getitem__(self, item: Union[bytes, str]) -> Union[bytes, str]:

--- a/get_secret_or_env_var/__init__.py
+++ b/get_secret_or_env_var/__init__.py
@@ -67,10 +67,11 @@ class _DockerSecretsDict:
             item = item.decode()
         except AttributeError:
             pass  # Not bytes
-        try:
+        secrets_path = DOCKER_SECRETS_PATH / item
+        if secrets_path.exists():
             with open(DOCKER_SECRETS_PATH / item, self.mode) as fin:
                 return fin.read().strip()
-        except FileNotFoundError:
+        else:
             raise KeyError
 
 


### PR DESCRIPTION
- Avoids the use of an f-string

- In Python 3.5, `pathlib` [doesn't](https://stackoverflow.com/questions/42694112/when-using-pathlib-getting-error-typeerror-invalid-file-posixpathexample-t) always work well with the native `open()` function, so it can throw `TypeError` instead of `FileNotFoundError` when a file doesn't exist. The tweak changes this to use the `.open()` method on the `Path` objects instead.